### PR TITLE
Add flag for checking global packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,11 @@
 - [x] Autocomplete
 - [x] Colored updatable packages based on semver diff
 - [x] CLI utility flags
+- [x] Check global packages
 
 ## Roadmap
 
 - [ ] Monorepo support ⚠️
-- [ ] Check global packages ⚠️
 - [ ] Single packages update with filters ⚠️
 - [ ] Non-interactive mode with different display formatting and infos (publish time, semver grouping ) ⚠️
 
@@ -43,6 +43,7 @@ pushapp
 
 | Option                              | Description                          |
 |-------------------------------------|--------------------------------------|
+| `-g`, `--global`                    | Check global packages                |
 | `-d`, `--development`               | Check only `devDependencies`         |
 | `-p`, `--production`                | Check only `dependencies`            |
 | `-o`, `--optional`                  | Check only `optionalDependencies`    |

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -1,7 +1,8 @@
 use clap::Parser;
 
-#[derive(Parser, Debug)]
+#[derive(Parser, Debug, Default)]
 #[command(version, about, long_about = None)]
+#[allow(clippy::struct_excessive_bools)]
 pub struct Args {
   /// Check only "devDependencies"
   #[clap(short, long)]
@@ -12,4 +13,7 @@ pub struct Args {
   /// Check only "optionalDependencies"
   #[clap(short, long)]
   pub optional: bool,
+  /// Check global packages
+  #[clap(short, long)]
+  pub global: bool,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,8 +12,10 @@ async fn main() -> Result<()> {
   let args = Args::parse();
 
   let mut pkg_manager = PackageJsonManager::new();
-  pkg_manager.locate_closest()?;
-  pkg_manager.read()?;
+  if !args.global {
+    pkg_manager.locate_closest()?;
+    pkg_manager.read()?;
+  }
 
   let update_checker = UpdateChecker::new(args, pkg_manager);
   update_checker.run().await?;


### PR DESCRIPTION
This pull request adds a new flag `-g` or `--global` to the CLI utility. When this flag is used, the utility will check for updates in the global packages instead of the local packages. The flag is added to the command line arguments and the `Args` struct. The logic for fetching and handling global packages is implemented in the `PackageJsonManager` and `UpdateChecker` modules.