### PR TITLE
Refactor package manager detection

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -2,6 +2,7 @@ pub mod args;
 pub mod fs_utils;
 pub mod package_info;
 pub mod package_json;
+pub mod package_manager;
 pub mod prompt;
 pub mod registry;
 pub mod updater;

--- a/src/cli/package_json.rs
+++ b/src/cli/package_json.rs
@@ -135,11 +135,8 @@ impl PackageJsonManager {
   }
 
   fn get_package_manager_from_json(&self) -> Option<PackageManager> {
-    self
-      .json
-      .package_manager
-      .as_ref()
-      .and_then(|pm| pm.split('@').next().map(Into::into))
+    let package_manager = self.json.package_manager.as_ref()?.split('@').next()?;
+    Some(PackageManager::from(package_manager))
   }
 
   fn detect_lock_file(&self) -> Option<PackageManager> {

--- a/src/cli/package_json.rs
+++ b/src/cli/package_json.rs
@@ -141,8 +141,8 @@ impl PackageJsonManager {
     self
       .json
       .package_manager
-      .as_deref()
-      .map(|pm| pm.split('@').next().unwrap().to_owned())
+      .as_ref()
+      .and_then(|pm| pm.split('@').next().map(std::convert::Into::into))
   }
 
   fn detect_lock_file() -> Result<Option<String>> {

--- a/src/cli/package_manager.rs
+++ b/src/cli/package_manager.rs
@@ -1,0 +1,65 @@
+use std::fmt::{Display, Formatter};
+
+#[derive(Debug, PartialEq)]
+pub enum PackageManager {
+  Npm,
+  Yarn,
+  Pnpm,
+  Bun,
+}
+
+const NPM: &str = "npm";
+const YARN: &str = "yarn";
+const PNPM: &str = "pnpm";
+const BUN: &str = "bun";
+
+pub const NPM_LOCK: &str = "package-lock.json";
+pub const YARN_LOCK: &str = "yarn.lock";
+pub const PNPM_LOCK: &str = "pnpm-lock.yaml";
+pub const BUN_LOCK: &str = "bun.lockb";
+
+impl PackageManager {
+  pub fn from_lock_file(lock_file: &str) -> Self {
+    match lock_file {
+      NPM_LOCK => Self::Npm,
+      YARN_LOCK => Self::Yarn,
+      PNPM_LOCK => Self::Pnpm,
+      BUN_LOCK => Self::Bun,
+      _ => unreachable!(),
+    }
+  }
+
+  pub fn to_str(&self) -> &'static str {
+    match self {
+      Self::Npm => NPM,
+      Self::Yarn => YARN,
+      Self::Pnpm => PNPM,
+      Self::Bun => BUN,
+    }
+  }
+
+  pub fn determine_install_command(&self) -> &str {
+    match self {
+      PackageManager::Npm => "install",
+      _ => "add",
+    }
+  }
+}
+
+impl Display for PackageManager {
+  fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    write!(f, "{}", self.to_str())
+  }
+}
+
+impl From<&str> for PackageManager {
+  fn from(s: &str) -> Self {
+    match s {
+      NPM => PackageManager::Npm,
+      YARN => PackageManager::Yarn,
+      PNPM => PackageManager::Pnpm,
+      BUN => PackageManager::Bun,
+      _ => unreachable!(),
+    }
+  }
+}


### PR DESCRIPTION
This pull request refactors the detect_package_manager function in the package_json.rs file. The function now includes improved logic for detecting the package manager used in the project. It first checks if the --global flag is set, and if so, returns "npm". If not, it checks if the package manager is specified in the package.json file and returns it if found. If not, it checks for the presence of lock files (yarn.lock, package-lock.json, pnpm-lock.yaml, bun.lockb) in the current directory and returns the corresponding package manager if found. If no package manager is detected, it defaults to "npm". The changes also include updated tests to verify the correct detection of the package manager.