### PR TITLE
Refactor dependencies flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@
 - [ ] Monorepo support ⚠️
 - [ ] Single packages update with filters ⚠️
 - [ ] Non-interactive mode with different display formatting and infos (publish time, semver grouping ) ⚠️
+- [ ] Tarball and git url dependencies support ⚠️
 
 ## Installation
 
@@ -41,14 +42,13 @@ pushapp
 
 ## Flag options
 
-| Option                              | Description                          |
-|-------------------------------------|--------------------------------------|
-| `-g`, `--global`                    | Check global packages                |
-| `-d`, `--development`               | Check only `devDependencies`         |
-| `-p`, `--production`                | Check only `dependencies`            |
-| `-o`, `--optional`                  | Check only `optionalDependencies`    |
-| `-h`, `--help`                      | Display help information             |
-| `-V`, `--version`                   | Display version information          |
+| Option                              | Description                                                   |
+|-------------------------------------|-------------------------------------------------------------- |
+| `-g`, `--global`                    | Check global packages                                         |
+| `-D`, `--development`               | Check only `devDependencies`                                  |
+| `-P`, `--production`                | Check only `dependencies and optionalDependencies`            |
+| `-h`, `--help`                      | Display help information                                      |
+| `-V`, `--version`                   | Display version information                                   |
 
 ## License
 

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -5,14 +5,11 @@ use clap::Parser;
 #[allow(clippy::struct_excessive_bools)]
 pub struct Args {
   /// Check only "devDependencies"
-  #[clap(short, long)]
+  #[clap(short('D'), long)]
   pub development: bool,
-  /// Check only "dependencies"
-  #[clap(short, long)]
+  /// Check only "dependencies" and "optionalDependencies"
+  #[clap(short('P'), long)]
   pub production: bool,
-  /// Check only "optionalDependencies"
-  #[clap(short, long)]
-  pub optional: bool,
   /// Check global packages
   #[clap(short, long)]
   pub global: bool,

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,5 +1,4 @@
 pub mod args;
-pub mod fs_utils;
 pub mod package_info;
 pub mod package_json;
 pub mod package_manager;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 mod cli;
+mod utils;
 
 use anyhow::Result;
 use clap::Parser;

--- a/src/utils/fs.rs
+++ b/src/utils/fs.rs
@@ -38,8 +38,8 @@ where
 
 #[cfg(test)]
 mod tests {
-  use super::super::package_json::PACKAGE_JSON_FILENAME;
   use super::*;
+  use crate::cli::package_json::PACKAGE_JSON_FILENAME;
   use std::io::Write;
   use tempfile::tempdir;
 

--- a/src/utils/hashmap.rs
+++ b/src/utils/hashmap.rs
@@ -1,0 +1,20 @@
+use std::collections::HashMap;
+use std::hash::Hash;
+
+// A function to merge multiple optional HashMaps into one.
+// It merges the additional HashMaps into the `base` HashMap.
+// Each element in `others` is an `Option<&HashMap<K, V>>`.
+pub fn merge<K, V>(others: &[Option<&HashMap<K, V>>]) -> HashMap<K, V>
+where
+  K: Eq + Hash + Clone,
+  V: Clone,
+{
+  let mut base = HashMap::new();
+  for map in others.iter().flatten() {
+    for (key, value) in *map {
+      base.insert(key.clone(), value.clone());
+    }
+  }
+
+  base
+}

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,0 +1,2 @@
+pub mod fs;
+pub mod hashmap;


### PR DESCRIPTION
Removed the `--optional` flag and merged `dependencies` and `optionalDependencies` when using the `-P` flag. Also added a new `utils` module for hashmaps and fs.