### PR TITLE
refactor: version target options and improve version matching

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,12 +45,31 @@ pushapp
 
 | Option                              | Description                                                                                        |
 |-------------------------------------|----------------------------------------------------------------------------------------------------|
-| `-t`, `--target`                    | Determines the version to upgrade to: latest, semver, major, minor, patch, pre                  |
+| `-t`, `--target`                    | Determines the version to upgrade to                                                               |
 | `-g`, `--global`                    | Check global packages                                                                              |
 | `-D`, `--development`               | Check only `devDependencies`                                                                       |
 | `-P`, `--production`                | Check only `dependencies and optionalDependencies`                                                 |
 | `-h`, `--help`                      | Display help information                                                                           |
 | `-V`, `--version`                   | Display version information                                                                        |
+
+## How dependencies updates are determined
+
+- Direct dependencies are updated to the latest stable version:
+  - `1.0.0` → `1.2.0`
+- Prerelease versions are ignored by default.
+  - Use `--target pre` to include prerelease versions (e.g. `alpha`, `beta`, `rc`)
+- Choose what level to upgrade to:
+  - With `--target semver`, update according to your specified [semver](https://semver.org/) version ranges:
+    - `^1.1.0` → `^1.9.99`
+  - With `--target major`, strictly update the major version:
+    - `1.0.0` → `2.0.0`
+  - With `--target minor`, strictly update the patch and minor versions (including major version zero):
+    - `0.1.0` → `0.2.1`
+  - With `--target patch`, strictly update the patch version (including major version zero):
+    - `0.1.0` → `0.1.2`
+  - With `--target [tag]`, update to the version published on the specified tag:
+    - Example: `0.1.0` -> `0.1.1-canary.1`
+    - The available target tags are `next`, `canary`, `rc`, `beta`, `alpha`. The default is `latest`.
 
 ## License
 

--- a/src/cli/flags.rs
+++ b/src/cli/flags.rs
@@ -6,21 +6,16 @@ use super::versions::VersionTarget;
 #[command(author, version, about, long_about = None)]
 #[allow(clippy::struct_excessive_bools)]
 pub struct Flags {
-  /// Check only "devDependencies"
+  /// Check only "devDependencies".
   #[clap(short('D'), long)]
   pub development: bool,
-  /// Check only "dependencies" and "optionalDependencies"
+  /// Check only "dependencies" and "optionalDependencies".
   #[clap(short('P'), long)]
   pub production: bool,
   /// Check global packages instead of in the current project.
   #[clap(short, long)]
   pub global: bool,
   /// Determines the version to upgrade to.
-  /// 1) `latest` means the latest version available in the registry, excluding pre-releases.
-  /// 2) `semver` means upgrade to the highest version within the semver range specified in your package.json.
-  /// 3) `major` means upgrade to the highest major version.
-  /// 4) `minor` means upgrade to the highest minor version without bumping the major version.
-  /// 5) `patch` means upgrade to the highest patch version without bumping the major or minor version.
   #[clap(short, long, verbatim_doc_comment, default_value = "latest")]
   pub target: VersionTarget,
 }

--- a/src/cli/registry/client.rs
+++ b/src/cli/registry/client.rs
@@ -44,14 +44,15 @@ impl RegistryClient {
   ) -> Result<Option<PackageInfo>> {
     let latest_version = self.fetch_package_version(name, flags).await?;
 
-    if is_version_satisfying(current_version, &latest_version, flags)? {
-      Ok(Some(PackageInfo {
-        pkg_name: name.to_string(),
-        current_version: current_version.to_string(),
-        latest_version: latest_version.to_string(),
-      }))
-    } else {
-      Ok(None)
+    match latest_version {
+      Some(version) if is_version_satisfying(current_version, &version, flags)? => {
+        Ok(Some(PackageInfo {
+          pkg_name: name.to_string(),
+          current_version: current_version.to_string(),
+          latest_version: version,
+        }))
+      }
+      _ => Ok(None),
     }
   }
 
@@ -59,7 +60,7 @@ impl RegistryClient {
     &self,
     name: &str,
     flags: &Flags,
-  ) -> Result<String, RegistryError> {
+  ) -> Result<Option<String>, RegistryError> {
     let dist_tags = self.fetch_registry(name).await?;
     let version_match = match_dist_tag_with_target(dist_tags, &flags.target);
 

--- a/src/cli/versions/version_target.rs
+++ b/src/cli/versions/version_target.rs
@@ -11,6 +11,11 @@ pub enum VersionTarget {
   Minor,
   Patch,
   Pre,
+  Next,
+  Canary,
+  Rc,
+  Beta,
+  Alpha,
 }
 
 impl fmt::Display for VersionTarget {
@@ -22,6 +27,11 @@ impl fmt::Display for VersionTarget {
       VersionTarget::Minor => write!(f, "minor"),
       VersionTarget::Patch => write!(f, "patch"),
       VersionTarget::Pre => write!(f, "pre"),
+      VersionTarget::Next => write!(f, "next"),
+      VersionTarget::Canary => write!(f, "canary"),
+      VersionTarget::Rc => write!(f, "rc"),
+      VersionTarget::Beta => write!(f, "beta"),
+      VersionTarget::Alpha => write!(f, "alpha"),
     }
   }
 }


### PR DESCRIPTION
This pull request refactors the version target options in the `Flags` struct, adding new options for `Next`, `Canary`, `Rc`, `Beta`, and `Alpha`. It also improves the version matching logic in the `is_version_satisfying` function. Additionally, the README.md file has been updated to include an explanation of how dependencies updates are determined based on the chosen target.